### PR TITLE
fix: return wrapped instance from exported module

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -225,7 +225,7 @@ export default function comlink({
               !isBuild || moduleWorker ? ", {type: 'module'}" : ""
             })
             ${!isBuild ? "workers.push(worker)" : ""}
-            wrap(worker)
+            return wrap(worker)
           }
         `;
       }


### PR DESCRIPTION
There's a missing `return` when refactored to module worker. Add it back.