### PR TITLE
fix: change default name of generated type file

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,9 +73,9 @@ export default {
       internal_worker_plugins: [],
       /**
        * Filename of type file
-       * @default comlink.d.ts
+       * @default comlink-workers.d.ts
        */
-      typeFile: "comlink.d.ts",
+      typeFile: "comlink-workers.d.ts",
       /**
        * Use module Worker in production
        * for support see https://caniuse.com/mdn-api_worker_worker_ecmascript_modules

--- a/src/index.ts
+++ b/src/index.ts
@@ -34,7 +34,7 @@ interface ComlinkPluginOptions {
   internal_worker_plugins?: string[];
   /**
    * Filename of type file
-   * @default comlink.d.ts
+   * @default comlink-workers.d.ts
    */
   typeFile?: string;
   /**
@@ -48,7 +48,7 @@ export default function comlink({
   moduleWorker = false,
   types = false,
   schema = "comlink:",
-  typeFile = "comlink.d.ts",
+  typeFile = "comlink-workers.d.ts",
   internal_worker_plugins = [
     "alias",
     "vite:modulepreload-polyfill",


### PR DESCRIPTION
The default generated type file is named "comlink.d.ts", which makes the
`import("comlink")` statement inside it to refer to that definition
itself instead of the real comlink package. Change the default name to
avoid the issue.