### PR TITLE
Adjust imports depending on the location of the typeFile

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -69,7 +69,7 @@ export default function comlink({
     },
     async resolveId(id, importer) {
       const keys = Object.keys(publicIds);
-      const typeFileDirectory = join(root!, dirname(typeFile != false ? dirname(typeFile) : ""))
+      const typeFileDirectory = join(root!, typeFile != false ? dirname(typeFile) : "")
       for (let i = 0; i < keys.length; i++) {
         if (id.startsWith(keys[i])) {
           const real = await this.resolve(id.slice(keys[i].length), importer);


### PR DESCRIPTION
This is a relatively small fix with TypeScript support, all this does is ensures that the generated `.d.ts` file uses the correct relative paths when importing workers.

This allows you to store the file inside your `src` directory along with other files instead of it sitting at the project root.

I didn't see any unit tests I could run to confirm there's no breaking changes but I did some testing locally and there's no regressions from what I can see with this fix.