### PR TITLE
fixed mismatch in parameter name

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -59,7 +59,7 @@ export function comlink({
             import {expose} from 'comlink'
             import * as api from '${normalizePath(realID)}'
 
-            addEventListener('connect', (ev) => {
+            addEventListener('connect', (event) => {
                 const port = event.ports[0];
                   
                 expose(api, port);


### PR DESCRIPTION
Shared workers don't work because event is declared as `ev` and used as if named `event`.