### PR TITLE
support ESM import for plugin

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,6 +9,13 @@
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "module": "dist/index.mjs",
+  "exports": {
+    ".": {
+      "import": "./dist/index.mjs",
+      "require": "./dist/index.js",
+      "types": "./dist/index.d.ts"
+    }
+  },
   "author": "Sebastian Krüger (@mathe42)",
   "license": "MIT",
   "scripts": {


### PR DESCRIPTION
There's already a `dist/index.mjs` entry file, it's just not being referenced using an `exports` field in the `package.json`. So Node can't resolve to it, even when running in ESM. The existing `"module"` field (not to be confused with `"type": "module"`, was never officially supported and is more for bundlers etc.

This PR simplify adds an `"exports"` field, which makes Node load the ESM version of the plugin, fixing https://github.com/mathe42/vite-plugin-comlink/issues/117 along the way.