### PR TITLE
Fix types import issue introduced in v4

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,6 +14,9 @@
       "import": "./dist/index.mjs",
       "require": "./dist/index.js",
       "types": "./dist/index.d.ts"
+    },
+    "./client": {
+      "types": "./client.d.ts"
     }
   },
   "author": "Sebastian Krüger (@mathe42)",


### PR DESCRIPTION
With the (blessed) introduction of v4, adding this to `vite-env.d.ts` stopped working:
`/// <reference types="vite-plugin-comlink/client" />`

It does not lead to the `client.d.ts` file that sits in the package root.

Adding the export in the `packages.json` file solves it.

Happy New Year and thanks for v4 🎉