### PR TITLE
Added missing filename when applying sourcemaps after generation

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -127,7 +127,7 @@ export function comlink({
         const thisSourcemapConsumer = await new SourceMapConsumer(s.generateMap());
 
         const sourceMapGen = SourceMapGenerator.fromSourceMap(thisSourcemapConsumer);
-        sourceMapGen.applySourceMap(prevSourcemapConsumer);
+        sourceMapGen.applySourceMap(prevSourcemapConsumer, id);
 
         return {
           code: s.toString(),


### PR DESCRIPTION
After the move to v4, I encountered this error during build:
`[comlink] SourceMapGenerator.prototype.applySourceMap requires either an explicit source file, or the source map's "file" property. Both were omitted.`

After investigating it seems like the `file` property was missing when calling `applySourceMap`