### PR TITLE
Use CommonJS in symbol.js

### DIFF
--- a/symbol.js
+++ b/symbol.js
@@ -1,11 +1,5 @@
 const { wrap: comlink_wrap } = require("comlink");
-const comlink = {
-    proxy,
-    proxyMarker,
-    finalizer,
-    releaseProxy,
-    createEndpoint
-} = require('comlink');
+const comlink = require('comlink');
 
 Object.assign(module.exports, comlink);
 

--- a/symbol.js
+++ b/symbol.js
@@ -1,17 +1,20 @@
-import { wrap as comlink_wrap } from "comlink";
-export {
+const { wrap: comlink_wrap } = require("comlink");
+const comlink = {
     proxy,
     proxyMarker,
     finalizer,
     releaseProxy,
     createEndpoint
-} from 'comlink'
-export const endpointSymbol = Symbol("getEndpoint");
+} = require('comlink');
+
+Object.assign(module.exports, comlink);
+
+const endpointSymbol = module.exports.endpointSymbol = Symbol("getEndpoint");
 
 /**
  * internal API
  */
-export const wrap = (ep) => {
+module.exports.wrap = (ep) => {
     const wrapped = comlink_wrap(ep);
     return new Proxy(wrapped, {
       get(_target, prop, _receiver) {


### PR DESCRIPTION
Fixes #155

Since the type of package is not a module in "package.json", the symbol.js file should be using CJS syntax.
